### PR TITLE
Set a default Licence for the wrapper package, as it has no build dir…

### DIFF
--- a/packagegroup-openplugins.bb
+++ b/packagegroup-openplugins.bb
@@ -38,4 +38,4 @@ DEPENDS = " \
 	enigma2-plugin-systemplugins-crossepg \
 "
 
-require assume-gplv2.inc
+LICENSE = "GPLv2"


### PR DESCRIPTION
…etcory to put a copy into.

This avoids an error message from trying to checksum a non-existent file.

```
ERROR: packagegroup-openplugins-1.0-r1 do_populate_lic: QA Issue: packagegroup-openplugins: LIC_FILES_CHKSUM points to an invalid file: /var/tmp/dev-build/oe-alliance/builds/openvix/developer/inihdx/tmp/work/all-oe-linux/packagegroup-openplugins/packagegroup-openplugins-1.0-r1/packagegroup-openplugins-1.0/../LICENSE.GPLv2 [license-checksum] 
```